### PR TITLE
Revert "[chore] yarn-script as linguist-generated by gitattr (#63)"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-.yarn/**/*.cjs linguist-generated


### PR DESCRIPTION
This reverts commit 3858edc60e88f2968920e597eb320a4417c9ee04.
